### PR TITLE
added custom matcher closes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,34 @@ npm install crud-compare
 ```js
 const compare = require("crud-compare");
 
+// comparing array of objects - using a single property as key.
 const { createdVals, updatedVals, deletedVals } = compare.compareObjectVals(
   [
     originalArrayOfObjects,
     newArrayOfObjects
   ],
-  relatedObjectKey
+  relatedObjectKey  // string - the name of the property to be used as key
 );
 
-// perform crud operations...
+// comparing array of objects - using custom matcher logic.
+matcher = (o1, o2) => o1.fName === o2.fName && o1.lName === o2.lName; // (o1: any, o2: any) => boolean
+const { createdVals, updatedVals, deletedVals } = compare.compareObjectVals(
+  [
+    originalArrayOfObjects,
+    newArrayOfObjects
+  ],
+  matcher
+);
 
+// comparing array of primitives values (based on strict equality)
 const { createdVals, deletedVals } = compare.compareArrayVals(
   [
     originalArrayItem,
     updatedArrayItem
   ]
 );
-// perform further operations...
 
+// helper function for comparing 2 objects - 1 level deep strict equality
 const areObjectsEquivalent = compare.isEqualObject(
   obj1,
   obj2

--- a/index.test.js
+++ b/index.test.js
@@ -9,6 +9,15 @@ const newArrayOfObjects = [
   {'commonKey': 7}
 ];
 
+const originalArrayOfComplexObjects = [
+  {'key1': 1, 'key2': '1', 'otherProperty': 'stuff 1'},
+  {'key1': 2, 'key2': '2', 'otherProperty': 'stuff 2'}
+];
+
+const newArrayOfComplexObjects = [
+  {'key1': 2, 'key2': '2', 'otherProperty': 'new stuff'},
+  {'key1': 7, 'key2': '7'}
+];
 describe('compareObjectVals Tests', () => {
   test('compareObjectVals functionality', () => {
     const { createdVals, updatedVals, deletedVals } = compareObjectVals(
@@ -22,6 +31,20 @@ describe('compareObjectVals Tests', () => {
     expect(createdVals).toStrictEqual([{'commonKey': 7}]);
     expect(updatedVals).toStrictEqual([{'commonKey': 2, 'newkey': 'test'}]);
     expect(deletedVals).toStrictEqual([{'commonKey': 1, 'anotherkey': 'test'}]);
+  });
+
+  test('compareObjectVals with complex key', () => {
+    const { createdVals, updatedVals, deletedVals } = compareObjectVals(
+    [
+      originalArrayOfComplexObjects,
+      newArrayOfComplexObjects
+    ],
+    (obj1, obj2) => obj1.key1 === obj2.key1 && obj1.key2 === obj2.key2
+    );
+
+    expect(createdVals).toStrictEqual([{'key1': 7, 'key2': '7'}]);
+    expect(updatedVals).toStrictEqual([{'key1': 2, 'key2': '2', 'otherProperty': 'new stuff'}]);
+    expect(deletedVals).toStrictEqual([{'key1': 1, 'key2': '1', 'otherProperty': 'stuff 1'}]);
   });
 
   test('empty original array of objects', () => {
@@ -75,7 +98,7 @@ describe('compareObjectVals Tests', () => {
       const { createdVals, updatedVals, deletedVals } = compareVals;
     } catch (e) {
       expect(e.message).toBe(`toCompareVals must be an array of the originalArray 
-    and stateUpdatedArray you want to compare, and the key must be of type string!`);
+    and stateUpdatedArray you want to compare, and the keyOrMatcher must be of type string or function!`);
     }
   })
 


### PR DESCRIPTION
PR includes also a little bit of refactoring to the matching logic.
it looks like it adds complexity - but it's actually not.
instead of saving the keys in a dedicated array and looping on it with `index of` - I loop over the original array using the custom comparer function.
also - using a simple string creates a custom comparer that use that key.